### PR TITLE
fix mariadb statefulset bug

### DIFF
--- a/manifests/installation/storage/mariadb/statefulset.yaml
+++ b/manifests/installation/storage/mariadb/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
         # 密码类的环境变量，为了安全，不能以明文的方式在 YAML 中指定，需要通过 secret 挂载
         envFrom:
           - secretRef:
-            name: mariadb
+              name: mariadb
   # 指定了要创建的持久化存储卷模板信息
   volumeClaimTemplates:
   # 指定了存储卷模板的元数据信息


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/superproj/community/blob/master/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://github.com/superproj/community/blob/master/contributors/devel/development.md#development-guide
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
-->
- **fix**: A bug fix

### scope 

- **etc.**: changes to all other code

### description

在执行命令`kubectl -n infra apply -f manifests/installation/storage/mariadb` 会报以下错误：
“Error from server (BadRequest): error when creating "manifests/installation/storage/mariadb/statefulset.yaml": StatefulSet in version "v1" cannot be handled as a StatefulSet: strict decoding error: unknown field "spec.template.spec.containers[0].envFrom[0].name"，
原因是：`statefulset.yaml`中
```yaml
        envFrom:
          - secretRef:
            name: mariadb
```
存在格式错误、应修改为：
```yaml
        envFrom:
          - secretRef:
              name: mariadb
```

