### PR TITLE
fix: fix missing mongo apt signing_key when install mongodb-mongosh

### DIFF
--- a/scripts/installation/mongo.sh
+++ b/scripts/installation/mongo.sh
@@ -44,6 +44,9 @@ onex::mongo::docker::install()
 
 onex::mongo::pre_install()
 {
+  # 获取 MongoDB 公钥
+  echo ${LINUX_PASSWORD} | sudo -S wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | sudo apt-key add -
+
   # 添加 MongoDB APT 源
   echo ${LINUX_PASSWORD} | sudo -S echo "deb [arch=amd64,arm64] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
 
@@ -73,9 +76,6 @@ onex::mongo::sbs::install()
   onex::mongo::pre_install
 
   echo ${LINUX_PASSWORD} | sudo -S apt install -y gnupg
-
-  # 获取 MongoDB 公钥
-  echo ${LINUX_PASSWORD} | sudo -S wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | sudo apt-key add -
 
   # 安装 MongoDB 服务端
   # 以为我们uninstall时会删除配置文件，所以要使用--force-confmiss 重新安装配置文件


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/superproj/community/blob/master/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://github.com/superproj/community/blob/master/contributors/devel/development.md#development-guide
-->

#### What type of PR is this?
bug fix/mongo install not sign
![320396787-f00e34de-762e-4525-85af-f1061f29682f](https://github.com/superproj/onex/assets/59298318/010e0e0d-8249-4137-a81a-5f8e47bc4714)



<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
-->

#### What this PR does / why we need it:
Move MongoDB GPG public key to the front



